### PR TITLE
Simplify define calls

### DIFF
--- a/string.polyfill.js
+++ b/string.polyfill.js
@@ -17,18 +17,12 @@
  * -------------------------------------------------------------------------------
  */
 if (!String.fromCodePoint) {
-  (function () {
-    var defineProperty = (function () {
-      try {
-        var object = {};
-        var $defineProperty = Object.defineProperty;
-        var result = $defineProperty(object, object, object) && $defineProperty;
-      } catch (error) {}
-      return result;
-    })();
-    var stringFromCharCode = String.fromCharCode;
-    var floor = Math.floor;
-    var fromCodePoint = function () {
+  var stringFromCharCode = String.fromCharCode;
+  var floor = Math.floor;
+  Object.defineProperty(String.prototype, 'fromCodePoint', {
+    configurable: true,
+    writable: true,
+    value: function () {
       var MAX_SIZE = 0x4000;
       var codeUnits = [];
       var highSurrogate;
@@ -45,7 +39,7 @@ if (!String.fromCodePoint) {
           !isFinite(codePoint) ||
           codePoint < 0 ||
           codePoint > 0x10ffff ||
-          floor(codePoint) != codePoint
+          Math.floor(codePoint) != codePoint
         ) {
           throw RangeError('Invalid code point: ' + codePoint);
         }
@@ -64,17 +58,8 @@ if (!String.fromCodePoint) {
         }
       }
       return result;
-    };
-    if (defineProperty) {
-      defineProperty(String, 'fromCodePoint', {
-        value: fromCodePoint,
-        configurable: true,
-        writable: true,
-      });
-    } else {
-      String.fromCodePoint = fromCodePoint;
-    }
-  })();
+    },
+  });
 }
 
 /**
@@ -109,8 +94,10 @@ if (!String.fromCodePoint) {
  * -------------------------------------------------------------------------------
  */
 if (!String.prototype.codePointAt) {
-  (function () {
-    var codePointAt = function (position) {
+  Object.defineProperty(String.prototype, 'codePointAt', {
+    configurable: true,
+    writable: true,
+    value: function (position) {
       if (this == null) {
         throw TypeError();
       }
@@ -132,17 +119,8 @@ if (!String.prototype.codePointAt) {
         }
       }
       return first;
-    };
-    if (Object.defineProperty) {
-      Object.defineProperty(String.prototype, 'codePointAt', {
-        value: codePointAt,
-        configurable: true,
-        writable: true,
-      });
-    } else {
-      String.prototype.codePointAt = codePointAt;
-    }
-  })();
+    },
+  });
 }
 
 /**

--- a/string.polyfill.js
+++ b/string.polyfill.js
@@ -39,7 +39,7 @@ if (!String.fromCodePoint) {
           !isFinite(codePoint) ||
           codePoint < 0 ||
           codePoint > 0x10ffff ||
-          Math.floor(codePoint) != codePoint
+          floor(codePoint) != codePoint
         ) {
           throw RangeError('Invalid code point: ' + codePoint);
         }

--- a/string.polyfill.js
+++ b/string.polyfill.js
@@ -19,7 +19,7 @@
 if (!String.fromCodePoint) {
   var stringFromCharCode = String.fromCharCode;
   var floor = Math.floor;
-  Object.defineProperty(String.prototype, 'fromCodePoint', {
+  Object.defineProperty(String, 'fromCodePoint', {
     configurable: true,
     writable: true,
     value: function () {


### PR DESCRIPTION
Assuming Object.defineProperty exists and works, as is the case in all target browsers, we don't need a fallback for extending String for fromCodePoint and codePointAt.