### PR TITLE
Accept depth argument in Array.prototype.flat

### DIFF
--- a/array.polyfill.js
+++ b/array.polyfill.js
@@ -544,17 +544,23 @@ if (!Array.prototype.flat) {
     configurable: true,
     writable: true,
     value: function () {
-      var stack = [].concat(this);
+      var depth =
+        typeof arguments[0] === 'undefined' ? 1 : Number(arguments[0]) || 0;
       var result = [];
-      while (stack.length) {
-        var next = stack.pop();
-        if (Array.isArray(next)) {
-          stack.push.apply(stack, next);
-        } else {
-          result.push(next);
-        }
-      }
-      return result.reverse();
+      var forEach = result.forEach;
+
+      var flatDeep = function (arr, depth) {
+        forEach.call(arr, function (val) {
+          if (depth > 0 && Array.isArray(val)) {
+            flatDeep(val, depth - 1);
+          } else {
+            result.push(val);
+          }
+        });
+      };
+
+      flatDeep(this, depth);
+      return result;
     },
   });
 }


### PR DESCRIPTION
Fixes #18.

As far as I see, this should be at least mostly spec-compatible,
although some of the more obscure edge cases may be left unhandled in
the name of code readability and size.

This also fixes a stack overflow error for very large Arrays (e.g.
`new Array(10**6)`), which was caused by the use of
`Array.prototype.push.apply(stack, large array)`.